### PR TITLE
Use named cache to prevent trampling

### DIFF
--- a/allwhois/_filecache.py
+++ b/allwhois/_filecache.py
@@ -18,6 +18,7 @@ import atexit
 _retval = _collections.namedtuple('_retval', 'timesig data')
 _SRC_DIR = _os.path.dirname(_os.path.abspath(__file__))
 _CACHE_STORE = '.cache'
+_MODULE_SUFFIX = '_' + _os.path.basename(_os.path.splitext(_sys.argv[0])[0])
 
 SECOND = 1
 MINUTE = 60 * SECOND
@@ -42,14 +43,14 @@ def _get_cache_name(function):
 
     # fix for '<string>' or '<stdin>' in exec or interpreter usage.
     cache_name = cache_name.replace('<', '').replace('>', '')
-    cache_name = _os.path.join(_CACHE_STORE, f'{cache_name}.cache')
+    cache_name = _os.path.join(_CACHE_STORE, f'{cache_name}{_MODULE_SUFFIX}.cache')
 
     return cache_name
 
 
 def _log_error(error_str):
     try:
-        error_log_fname = _os.path.join(_SRC_DIR, 'filecache.err.log')
+        error_log_fname = _os.path.join(_SRC_DIR, 'filecache{_MODULE_SUFFIX}.err.log')
         if _os.path.isfile(error_log_fname):
             fhand = open(error_log_fname, 'a')
         else:


### PR DESCRIPTION
If two scripts are running at the same time utilising allwhois, only the first works.  Any further will crash upon import due to file sharing violations.  This appends the base script name to the cache filename to prevent trampling